### PR TITLE
Use golang-native functions for interfacing with aspell

### DIFF
--- a/pptext.go
+++ b/pptext.go
@@ -3914,8 +3914,7 @@ func main() {
 
 	pptr = append(pptr, fmt.Sprintf("☲processing file: %s", path.Base(p.Infile)))
 
-	mycommand := fmt.Sprintf("file %s", p.Infile)
-	out, err := exec.Command("bash", "-c", mycommand).Output()
+	out, err := exec.Command("file", p.Infile).Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Rather than using temporary files and bash pipes to interact with aspell, use golang-native structures. This reduces the program's exposure to the bash shell.

This is my first foray into golang, so I would appreciate you building and testing it out @asylumcs.