### PR TITLE
Include the git hash and build date as part of pptext version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all build
+
+all: build
+
+build:
+	TIME=$$(date --utc --iso-8601=minutes | cut -c1-16); \
+	HASH=$$(git rev-parse HEAD | cut -c1-9); \
+	go build -ldflags "-X main.gitHash=$$HASH -X main.buildTime=$$TIME" pptext.go

--- a/pptext.go
+++ b/pptext.go
@@ -65,7 +65,11 @@ import (
 	"unicode/utf8"
 )
 
-const VERSION string = "2020.07.05"
+var (
+	gitHash   string // git hash when the exec was built
+	buildTime string // time when when the exec was built
+)
+
 const SHOWTIMING bool = false
 
 var sw []string      // suspect words list
@@ -3908,7 +3912,8 @@ func main() {
 	p = doparams() // parse command line parameters
 
 	if p.Revision {
-		fmt.Println(VERSION)
+		fmt.Println("Version:", gitHash)
+		fmt.Println("  Built:", buildTime)
 		return
 	}
 
@@ -3923,7 +3928,7 @@ func main() {
 
 	pptr = append(pptr, fmt.Sprintf("encoding: %s", strings.TrimSpace(o2[1])))
 
-	pptr = append(pptr, fmt.Sprintf("pptext version: %s", VERSION))
+	pptr = append(pptr, fmt.Sprintf("pptext version: %s @ %s", gitHash, buildTime))
 
 	f, _ := os.Create(p.Outdir + "/runlog.txt")
 	f.WriteString("started: " + time.Now().In(loc).Format(time.RFC850) + "\n")

--- a/pptext.go
+++ b/pptext.go
@@ -3917,6 +3917,10 @@ func main() {
 		return
 	}
 
+	if p.Infile == "" {
+		log.Fatal("No input file specified")
+	}
+
 	pptr = append(pptr, fmt.Sprintf("☲processing file: %s", path.Base(p.Infile)))
 
 	mycommand := fmt.Sprintf("file %s", p.Infile)


### PR DESCRIPTION
Include the git hash and the build date in the pptext binary and have it reported as the version command. The git hash is the best way to understand what version they are running but the build date is much more human friendly -- so why not include both. Note that the timestamp is always in UTC.

```
$ ./pptext -r
Version: 9b96e92ef
  Built: 2020-12-09T01:37
```

And in the `report.html` file:
```
pptext version: 9b96e92ef @ 2020-12-09T01:37
```