### PR TITLE
removed continued quote lookahead in scan

### DIFF
--- a/pptext.go
+++ b/pptext.go
@@ -673,14 +673,6 @@ func puncScan() []string {
 			// at the EOF one past the last line.
 			// process what we have and reset
 
-			// if stack has an ODQ, look ahead and see if it may be a continued quote
-			r2 := Peek()
-			if r2.punc == "“" {
-				if i < len(lwbuf)-1 && strings.HasPrefix(strings.TrimSpace(lwbuf[i+1]), "“") {
-					_ = Pop() // continued quote
-				}
-			}
-
 			// anything on stack at this point is an error
 			if len(pstack) > 0 {
 				stacklst := ""


### PR DESCRIPTION
This change deletes lines 676-682 of pptext.go because it misses unclosed double quotes during the punctuation scan, thinking it's a continued quote (because it can't detect a change of speaker). With those lines removed, it will report an @NESK (non-empty stack) because there is a unmatched open double quote, and that's what we want it to do. Users report they would rather have false positives in this situation than have it miss an unmatched double quote.