### PR TITLE
Remove empty words from word list

### DIFF
--- a/pptext.go
+++ b/pptext.go
@@ -3748,7 +3748,10 @@ func readWordList(infile string) ([]string, int) {
 	defer file.Close() // here if it opened
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		wd = append(wd, scanner.Text())
+		// skip blank lines
+		if scanner.Text() != "" {
+			wd = append(wd, scanner.Text())
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Empty "words" causes pptext to consume an obnoxious amount of memory.